### PR TITLE
Implement reading and writing EDF files

### DIFF
--- a/src/EEGIO.jl
+++ b/src/EEGIO.jl
@@ -23,7 +23,8 @@ export BDF, BDFHeader, read_bdf, write_bdf
 #EDF files
 include("formats/EDF.jl")
 include("load/load_edf.jl")
-export EDF, EDFHeader, read_edf
+include("save/save_edf.jl")
+export EDF, EDFHeader, read_edf, write_edf
 
 # EEG files
 include("formats/EEG.jl")

--- a/src/EEGIO.jl
+++ b/src/EEGIO.jl
@@ -20,11 +20,19 @@ include("load/load_bdf.jl")
 include("save/save_bdf.jl")
 export BDF, BDFHeader, read_bdf, write_bdf
 
+#EDF files
+include("formats/EDF.jl")
+include("load/load_edf.jl")
+export EDF, EDFHeader, read_edf
+
 # EEG files
 include("formats/EEG.jl")
 include("load/load_eeg.jl")
 include("save/save_eeg.jl")
 export EEG, EEGHeader, EEGMarkers, read_eeg, write_eeg
+
+# Convenient type unions
+BEDFHeader = Union{BDFHeader, EDFHeader}
 
 # Helper functions
 include("utils/pick_channels.jl")

--- a/src/formats/EDF.jl
+++ b/src/formats/EDF.jl
@@ -1,0 +1,36 @@
+mutable struct EDFHeader <: Header
+    version::String
+    patientID::String
+    recordingID::String
+    startDate::String
+    startTime::String
+    nBytes::Int64
+    reserved44::String
+    nDataRecords::Int64
+    recordDuration::Float64
+    nChannels::Int64
+    chanLabels::Vector{String}
+    transducer::Vector{String}
+    physDim::Vector{String}
+    physMin::Vector{Float64}
+    physMax::Vector{Float64}
+    digMin::Vector{Float64}
+    digMax::Vector{Float64}
+    prefilt::Vector{String}
+    nSampRec::Vector{Int64}
+    reserved32::Vector{String}
+end
+
+mutable struct EDF <: EEGData
+    header::EDFHeader
+    data::Vector
+    path::String
+    file::String
+end
+
+Base.show(io::IO, edf::EDFHeader) = print(io, "EDF Header")
+function Base.show(io::IO, m::MIME"text/plain", edf::EDF) 
+    print(io, 
+    "EDF file ($(edf.header.nChannels) channels, \
+    duration: $(round(edf.header.nDataRecords/60,digits=2)) min.)")
+end

--- a/src/load/load_edf.jl
+++ b/src/load/load_edf.jl
@@ -1,0 +1,221 @@
+
+"""
+    read_edf(f::String; kwargs...)
+
+Read data from an EDF file.
+
+Providing a string containing valid path to a .edf file will result in reading the data
+as a Float64 matrix with an added offset. Behavior of the function can be altered through
+additional keyword arguments listed below. Please consult the online documentation for
+a more thorough explanation of different options.
+
+## Arguments:
+- `f::String`
+    - Path to the EDF file to be read.
+
+## Keywords:
+- `onlyHeader::Bool=false`
+    - Indicates whether to read the header information with data points or just the header.
+- `addOffset::Bool=true`
+    - Whether to add constant offset to data points to compensate for asymmetric digitalization
+      done by the amplifier. This setting differs between software. Defaults to `true`.
+- `numPrecision::Type=Float64`
+    - Specifies the numerical type of the data. Data points in EDF files are stored as signed
+      16-bit integers, therefore can be read as types with higher bit count per number.
+      Possible tested options: `Float32`, `Float64`, `Int32`, `Int64`. Since there is no clear
+      benefit (except amount of memory used) to using smaller number, the default is set to 
+      `Float64`.
+- `chanSelect::Union{Int, Range, Vector{Int}, String, Vector{String}, Regex, Symbol}=:All`
+    - Specifies the subset of channels to read from the data. Depending on the provided value
+      you can select different subsets of channels.
+      Using integers (either single number, range, or a vector) will select channels by their
+      position in the data (e.g. chanSelect=[1,4,8], will pick the first, fourth, and eighth).
+      Using strings or regex expression will pick all the channels with matching names stored
+      in the header.
+      Finally, you can provide symbols :None or :All to read neither or every channel available.
+      Default is set to :All.
+- `chanIgnore::Union{Int, UnitRange, Vector{Int}, String, Vector{String}, Regex, Symbol}=:None`
+    - Specifies the subset of channel to omit while reading the data.
+      Uses the same selectors as `chanSelect` and picked values are subtracted from the set
+      of electrodes chosen by `chanSelect`. Default is set to :None.
+- `timeSelect::Union{Int, UnitRange, Tuple{AbstractFloat}, Symbol}=:All`
+    - Specifies the part of the time course of the data to be read.
+      EDF files are read one record at a time (just as they are written), so the user can
+      indicate which records to read.
+      Using integers will select records with those indexes in the data.
+      Using a tuple of floats will be interpreted as start and stop values in seconds
+      and all records that fit this time span will be read.
+      Using Symbol :All will read every record in the file. This is also the default.
+- `method::Symbol=:Direct`
+    - Choose the IO method of reading data. Can be either :Direct (set as the default) for 
+      reading the file in chunks or :Mmap for using memory mapping.
+- `tasks::Int=1`
+    - Specifies how many concurent tasks will be spawn to read chunks of data. Tasks will use
+      as many threads as there are available to Julia, but users can specify a higher number.
+      Default is set to 1 (equal to single threaded run).
+
+Current implementation follows closely the specification formulated in the original 
+[scientific article](https://doi.org/10.1016/0013-4694(92)90009-7). Here, we used a summary 
+from a [reference website](https://www.edfplus.info/specs/edf.html).
+EDF+ extension is not yet implemented.
+"""
+function read_edf(f::String; kwargs...)
+    # Check if an existing path is given, then open the file
+    if ispath(f)
+        path, file = splitdir(f)
+        open(f) do fid
+            read_edf(fid; path=path, file=file, kwargs...)
+        end
+    else
+        error("$f is not a valid file path.")
+    end
+end
+
+# Internal function called by public API
+function read_edf(fid::IO; path="", file="", onlyHeader=false, addOffset=true, numPrecision=Float64, 
+    chanSelect=:All, chanIgnore=:None, timeSelect=:All, method=:Direct, tasks=1)
+
+    # Read the header
+    header = read_edf_header(fid)
+
+    if onlyHeader
+        data = Vector{numPrecision}(undef, 0)
+    else
+        # Read the data
+        data = read_edf_data(fid, header, addOffset, numPrecision, chanSelect, chanIgnore, timeSelect, method, tasks)
+    end
+
+    return EDF(header, data, path, file)
+end
+
+"""
+    read_edf_header(::IO)
+
+Read the header of a EDF file.
+"""
+function read_edf_header(fid::IO)
+    # Read the general recording data
+    version =           decodeString(fid, 8)
+    patientID =         decodeString(fid, 80)
+    recordingID =       decodeString(fid, 80)
+    startDate =         decodeString(fid, 8)
+    startTime =         decodeString(fid, 8)
+    nBytes =            decodeNumber(fid, Int64, 8)
+    reserved44 =        decodeString(fid, 44)
+    nDataRecords =      decodeNumber(fid, Int64, 8)
+    recordDuration =    decodeNumber(fid, Float64, 8)
+    nChannels =         decodeNumber(fid, Int64, 4)
+
+    # Read the data channel specific information
+    chanLabels =    decodeChanStrings(fid, nChannels, 16)
+    transducer =    decodeChanStrings(fid, nChannels, 80)
+    physDim =       decodeChanStrings(fid, nChannels, 8)
+    physMin =       decodeChanNumbers(fid, Float64, nChannels, 8)
+    physMax =       decodeChanNumbers(fid, Float64, nChannels, 8)
+    digMin =        decodeChanNumbers(fid, Float64, nChannels, 8)
+    digMax =        decodeChanNumbers(fid, Float64, nChannels, 8)
+    prefilt =       decodeChanStrings(fid, nChannels, 80)
+    nSampRec =      decodeChanNumbers(fid, Int64, nChannels, 8)
+    reserved32 =    decodeChanStrings(fid, nChannels, 32)
+
+    return EDFHeader(version, patientID, recordingID, startDate, startTime, nBytes, 
+    reserved44, nDataRecords, recordDuration, nChannels, chanLabels, transducer, 
+    physDim, physMin, physMax, digMin, digMax, prefilt, nSampRec, reserved32)
+end
+
+# Main data read function that gets specialized based on user choices
+function read_edf_data(fid::IO, header::EDFHeader, addOffset, numPrecision, chanSelect, chanIgnore, timeSelect, method, tasks)
+    allSamples = header.nDataRecords .* header.nSampRec
+    recSamples = sum(header.nSampRec)
+
+    scaleFactors, offsets = resolve_offsets(header, addOffset, numPrecision)
+
+    # Limiting the number of channels and records to a requested subset.
+    records = pick_samples(header, timeSelect)
+    chans = pick_channels(header, chanSelect)
+    chans = setdiff(chans, pick_channels(header, chanIgnore))
+
+    # Decide how to access the datafile
+    raw = read_method(fid, method, Vector{Int16}, sum(allSamples))
+    data = [Vector{numPrecision}(undef, len) for len in length(records) .* header.nSampRec[chans]]
+
+    read_edf_data!(raw, data, header, recSamples, records, chans, scaleFactors, offsets, tasks)
+
+    # Update the header to reflect the subset of data actually read.
+    update_header!(header, records)
+    update_header!(header, chans)
+
+    return data
+end
+
+# Read data directly to a buffer in chunks
+function read_edf_data!(raw::IO, data, header, recSamples, records, chans, scaleFactors, offsets, tasks)
+    chanOffset = vcat([1], accumulate(+, header.nSampRec, init=1)[1:end-1])
+
+    scratch = TaskLocalValue{Vector{Int16}}(() -> Vector{Int16}(undef, recSamples))
+    dataStart = TaskLocalValue{Vector{Int}}(() -> Vector{Int}(undef, length(chans)))
+    dataEnd = TaskLocalValue{Vector{Int}}(() -> Vector{Int}(undef, length(chans)))
+
+    posi = position(raw)
+    readLock = ReentrantLock()
+
+    tforeach(records; scheduler=DynamicScheduler(; nchunks=tasks)) do recIdx 
+        parse_record!(raw, data, scratch[], dataStart[], dataEnd[], recIdx, header, readLock, posi, recSamples, chans, chanOffset, scaleFactors, offsets)
+    end
+
+    return nothing
+end
+
+# Read data from on record into a buffer and copy it to the output matrix
+function parse_record!(fid, data, scratch, dataStart, dataEnd, recIdx, header, readLock, posi, recSamples, chans, chanOffset, scaleFactors, offsets)
+    @views dataStart .= (recIdx-1) .* header.nSampRec[chans] .+ 1
+    @views dataEnd .= recIdx .* header.nSampRec[chans]
+    rawOffset = posi + 2 * (recIdx-1) * recSamples
+    lock(readLock) do 
+        seek(fid, rawOffset)
+        read!(fid, scratch)
+    end
+
+    for col in eachindex(data)
+        parse_channel!(scratch, data, col, chans, dataStart, dataEnd, 0, chanOffset, header.nSampRec, scaleFactors, offsets)
+    end
+
+    return nothing
+end
+
+# Read data through mmap
+function read_edf_data!(raw::Vector, data, header, recSamples, records, chans, scaleFactors, offsets, tasks)
+    chanOffset = vcat([1], accumulate(+, header.nSampRec, init=1)[1:end-1])
+
+    dataStart = TaskLocalValue{Vector{Int}}(() -> Vector{Int}(undef, length(chans)))
+    dataEnd = TaskLocalValue{Vector{Int}}(() -> Vector{Int}(undef, length(chans)))
+
+    tforeach(1:length(records); scheduler=DynamicScheduler(; nchunks=tasks)) do ridx
+        parse_record!(raw, data, header, records, ridx, recSamples, chans, chanOffset, dataStart[], dataEnd[], scaleFactors, offsets)
+    end
+
+    return nothing
+end
+
+# Find the indices of the record in the input vector and copy it to the output matrix
+function parse_record!(raw::Vector{Int16}, data, header, records, ridx, recSamples, chans, chanOffset, dataStart, dataEnd, scaleFactors, offsets)
+    rawOffset = (records[ridx] - 1) * recSamples
+    @views dataStart .= (ridx - 1) .* header.nSampRec[chans] .+ 1
+    @views dataEnd .= ridx .* header.nSampRec[chans]
+
+    for col in eachindex(data)
+        parse_channel!(raw, data, col, chans, dataStart, dataEnd, rawOffset, chanOffset, header.nSampRec, scaleFactors, offsets)
+    end
+
+    return nothing
+end
+
+# Copy data for a channel with promotion to a longer Integer, if necessary
+@inline function parse_channel!(raw::Vector{Int16}, data::Vector{Vector{T}}, col, chans, dataStart, dataEnd, rawOffset, chanOffset, nSampRec, scaleFactors, offsets) where T <: Integer
+    @views data[col][dataStart[col]:dataEnd[col]] .= raw[rawOffset+chanOffset[chans[col]]:rawOffset+chanOffset[chans[col]]+nSampRec[chans[col]]-1]
+end
+
+# Copy data for a channel with promotion to a floating point number with scaling and offset correction
+@inline function parse_channel!(raw::Vector{Int16}, data::Vector{Vector{T}}, col, chans, dataStart, dataEnd, rawOffset, chanOffset, nSampRec, scaleFactors, offsets) where T <: AbstractFloat
+    @views data[col][dataStart[col]:dataEnd[col]] .= raw[rawOffset+chanOffset[chans[col]]:rawOffset+chanOffset[chans[col]]+nSampRec[chans[col]]-1] .* scaleFactors[chans[col]] .+ offsets[chans[col]]
+end

--- a/src/load/load_edf.jl
+++ b/src/load/load_edf.jl
@@ -159,7 +159,8 @@ function read_edf_data!(raw::IO, data, header, recSamples, records, chans, scale
     posi = position(raw)
     readLock = ReentrantLock()
 
-    tforeach(records; scheduler=DynamicScheduler(; nchunks=tasks)) do recIdx 
+    @tasks for recIdx in records
+        @set scheduler = DynamicScheduler(; nchunks=tasks)
         parse_record!(raw, data, scratch[], dataStart[], dataEnd[], recIdx, header, readLock, posi, recSamples, chans, chanOffset, scaleFactors, offsets)
     end
 
@@ -190,7 +191,8 @@ function read_edf_data!(raw::Vector, data, header, recSamples, records, chans, s
     dataStart = TaskLocalValue{Vector{Int}}(() -> Vector{Int}(undef, length(chans)))
     dataEnd = TaskLocalValue{Vector{Int}}(() -> Vector{Int}(undef, length(chans)))
 
-    tforeach(1:length(records); scheduler=DynamicScheduler(; nchunks=tasks)) do ridx
+    @tasks for ridx in records
+        @set scheduler = DynamicScheduler(; nchunks=tasks)
         parse_record!(raw, data, header, records, ridx, recSamples, chans, chanOffset, dataStart[], dataEnd[], scaleFactors, offsets)
     end
 

--- a/src/save/save_bdf.jl
+++ b/src/save/save_bdf.jl
@@ -48,43 +48,6 @@ function write_bdf_header(fid, bdf::BDF)
     write_channel_records(fid, chans, header.reserved, 32)
 end
 
-# Write the general data information
-function write_record(fid, field, fieldLength; default="")
-    # Prepare the entry.
-    if field == ""
-        record = rpad(string(default), fieldLength)
-    else
-        if length(field)>fieldLength
-            @warn "Header field \"$field\"
-                    is longer than required $fieldLength bytes and will be truncated."
-        end
-        record = rpad(string(field),fieldLength)
-    end
-
-    # Write bytes to file
-    write(fid, codeunits(record))
-end
-
-# Write the chennel specific information
-function write_channel_records(fid, nChannels, field, fieldLength; default="")
-    for chan in 1:nChannels
-        #Prepare the entry for each channel.
-        if field == ""
-            record = rpad(string(default), fieldLength)
-        else
-            if length(field[chan])>fieldLength
-                @warn "Header field \"$field\" entry on position $chan
-                        is longer than required $fieldLength bytes and will be truncated."
-            end
-            record = rpad(string(field[chan]), fieldLength)
-        end
-
-        # Write bytes to file
-        write(fid, codeunits(record))
-    end
-end
-
-
 # Write data into a file.
 function write_bdf_data(fid, header, data, useOffset, method, chunk)
     scaleFactor = Float32.(header.physMax-header.physMin)./(header.digMax-header.digMin)

--- a/src/save/save_edf.jl
+++ b/src/save/save_edf.jl
@@ -1,0 +1,108 @@
+function write_edf(f::String, edf::EDF; overwrite=false, kwargs...)
+    if isfile(f)
+        if overwrite
+            rm(f)
+        else
+            error("File $f already exists. Use `overwrite=true` to overwrite the file.")
+        end
+    end
+    open(f, "w+", lock = false) do fid
+        write_edf(fid, edf; kwargs...)
+    end
+end
+
+function write_edf(fid::IO, edf::EDF; useOffset=true, method=:Direct, tasks=1)
+    # Write the header
+    write_edf_header(fid, edf)
+
+    write_edf_data(fid, edf.header, edf.data, useOffset, method, tasks=1)
+end
+
+function write_edf_header(fid, edf::EDF)
+    
+    header = edf.header
+
+    write_record(fid, header.version, 8)
+    write_record(fid, header.patientID,80)
+    write_record(fid, header.recordingID, 80)
+    write_record(fid, header.startDate, 8)
+    write_record(fid, header.startTime, 8)
+    write_record(fid, header.nBytes, 8)
+    write_record(fid, header.reserved44, 44)
+    write_record(fid, header.nDataRecords, 8)
+    write_record(fid, header.recordDuration, 8)
+    write_record(fid, header.nChannels, 4)
+    chans = header.nChannels
+    write_channel_records(fid, chans, header.chanLabels, 16)
+    write_channel_records(fid, chans, header.transducer, 80)
+    write_channel_records(fid, chans, header.physDim, 8)
+    write_channel_records(fid, chans, header.physMin, 8)
+    write_channel_records(fid, chans, header.physMax, 8)
+    write_channel_records(fid, chans, Int.(header.digMin), 8)
+    write_channel_records(fid, chans, Int.(header.digMax), 8)
+    write_channel_records(fid, chans, header.prefilt, 80)
+    write_channel_records(fid, chans, header.nSampRec, 8)
+    write_channel_records(fid, chans, header.reserved32, 32)
+end
+
+function write_edf_data(fid, header, data, useOffset, method, tasks)
+    scaleFactors, offsets = resolve_offsets(header, useOffset, Float64)
+
+    records = header.nDataRecords
+    channels = header.nChannels
+    duration = header.recordDuration
+    samples = header.nSampRec
+
+    output = read_method(fid, method, Vector{Int16}, sum(records .* samples))
+
+    write_edf_data(output, data, records, samples, channels, scaleFactors, offsets, tasks)
+end
+
+# Write using direct IO
+function write_edf_data(output::IO, data, records, samples, channels, scaleFactors, offsets, tasks)
+    
+    buffer = Vector{Int16}(undef, sum(samples))
+    recIdx = TaskLocalValue{Vector{Int}}(() -> Vector{Int}(undef, length(samples)))
+    recCum = 0
+
+    for record in 1:records
+        recIdx[] .= (record-1) .* samples
+        write_record(buffer, data, recIdx[], recCum, samples, channels, scaleFactors, offsets)
+
+        write(output, buffer)
+    end
+end
+
+# Multithreaded write using Mmap
+function write_edf_data(output::Vector{Int16}, data, records, samples, channels, scaleFactors, offsets, tasks)
+
+    recIdx = TaskLocalValue{Vector{Int}}(() -> Vector{Int}(undef, length(samples)))
+    recCum = TaskLocalValue{Int}(() -> 0)
+    
+    @tasks for record in 1:records
+        @set scheduler = DynamicScheduler(; nchunks=tasks)
+        recIdx[] .= (record-1) .* samples
+        recCum[] = sum(recIdx[])
+        write_record(output, data, recIdx[], recCum[], samples, channels, scaleFactors, offsets)
+    end
+    # Necessary to properly close the mmaped file.
+    finalize(output)
+end
+
+function write_record(output, data, recIdx, recCum, samples, channels, scaleFactors, offsets)
+    for chan in 1:channels
+        chanIdx = sum(view(samples, 1:(chan-1)))
+        for sample in 1:samples[chan]
+            sampIdx = recCum + chanIdx + sample
+            recode_value(data, output, recIdx, sampIdx, sample, chan, offsets, scaleFactors)
+        end
+    end
+end
+
+function recode_value(data::Vector{Vector{T}}, output::Vector{Int16}, recIdx, sampIdx, sample, chan, offsets, scaleFactors) where T <: AbstractFloat
+    output[sampIdx] = round(Int16, (data[chan][recIdx[chan]+sample] - offsets[chan])/scaleFactors[chan])
+end
+
+function recode_value(data::Vector{Vector{T}}, output::Vector{Int16}, recIdx, sampIdx, sample, chan, offsets, scaleFactors) where T <: Integer
+    output[sampIdx] = data[chan][recIdx[chan]+sample]
+end

--- a/src/utils/misc.jl
+++ b/src/utils/misc.jl
@@ -33,6 +33,42 @@ function decodeChanNumbers(fid, numType, nChannels, size)
     return arr
 end
 
+# Write the general data information
+function write_record(fid, field, fieldLength; default="")
+    # Prepare the entry.
+    if field == ""
+        record = rpad(string(default), fieldLength)
+    else
+        if length(field)>fieldLength
+            @warn "Header field \"$field\"
+                    is longer than required $fieldLength bytes and will be truncated."
+        end
+        record = rpad(string(field),fieldLength)
+    end
+
+    # Write bytes to file
+    write(fid, codeunits(record))
+end
+
+# Write the chennel specific information
+function write_channel_records(fid, nChannels, field, fieldLength; default="")
+    for chan in 1:nChannels
+        #Prepare the entry for each channel.
+        if field == ""
+            record = rpad(string(default), fieldLength)
+        else
+            if length(field[chan])>fieldLength
+                @warn "Header field \"$field\" entry on position $chan
+                        is longer than required $fieldLength bytes and will be truncated."
+            end
+            record = rpad(string(field[chan]), fieldLength)
+        end
+
+        # Write bytes to file
+        write(fid, codeunits(record))
+    end
+end
+
 # Calculate scaling and offsets for EDF/BDF data while checking if including them makes sense.
 function resolve_offsets(header, addOffset, numPrecision)
     if addOffset & (numPrecision <: Integer)

--- a/src/utils/resize.jl
+++ b/src/utils/resize.jl
@@ -3,29 +3,25 @@
 # These functions are also sed in the main read functions.
 
 # Functions to update BDF header.
-function update_header(header::BDFHeader, change)
+function update_header(header::BEDFHeader, change)
     newHeader = deepcopy(header)
     update_header!(newHeader, change)
     return newHeader
 end
 
-function update_header!(header::BDFHeader, records::UnitRange)
+function update_header!(header::BEDFHeader, records::UnitRange)
     header.nDataRecords = length(records)
 end
 
-function update_header!(header::BDFHeader, chans::Vector)
+function update_header!(header::BEDFHeader, chans::Vector)
     header.nBytes = (length(chans)+1)*256
     header.nChannels = length(chans)
-    header.chanLabels = header.chanLabels[chans]
-    header.transducer = header.transducer[chans]
-    header.physDim = header.physDim[chans]
-    header.physMin = header.physMin[chans]
-    header.physMax = header.physMax[chans]
-    header.digMax = header.digMax[chans]
-    header.digMin = header.digMin[chans]
-    header.prefilt = header.prefilt[chans]
-    header.reserved = header.reserved[chans]
-    header.nSampRec = header.nSampRec[chans]
+
+    for hfield in fieldnames(typeof(header))
+        if typeof(getfield(header, hfield)) <: AbstractVector
+            setfield!(header, hfield, getfield(header, hfield)[chans])
+        end
+    end
 end
 
 # Functions to update EEG header.


### PR DESCRIPTION
This pull request tracks adding functionality for handling EDF files.

Implementation will follow closely the structure of code for BDF files that is already in the package.
I opted for a separate set of functions because EDF files allow for signals with different sample rate that EEGIO will not automatically correct for. Therefore data will be stored in a vector of vectors of different length.
It should be possible to unify them both into a single implementation, however it might be beneficial to cover also EDF+ and BDF+ functionality and then rework them into one set of functions.