### PR TITLE
Handling SET files from EEGLab

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Marcin Koculak <koculak.marcin@gmail.com>"]
 version = "0.1.0"
 
 [deps]
+MAT = "23992714-dd62-5051-b70f-ba57cb901cac"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 OhMyThreads = "67456a42-1dca-4109-a031-0a68de7e3ad5"
 

--- a/src/EEGIO.jl
+++ b/src/EEGIO.jl
@@ -1,9 +1,9 @@
 module EEGIO
 
 using Mmap
-using Base.Iterators: partition
-using OhMyThreads: @tasks, TaskLocalValue, DynamicScheduler
 using MAT
+using OhMyThreads: @tasks, @set, @local, chunks
+
 
 # TODO make a test to check if this value is updated
 # with Pkg.TOML.parsefile(joinpath(pkgdir(EEGIO), "Project.toml"))["version"]

--- a/src/EEGIO.jl
+++ b/src/EEGIO.jl
@@ -3,6 +3,7 @@ module EEGIO
 using Mmap
 using Base.Iterators: partition
 using OhMyThreads: @tasks, TaskLocalValue, DynamicScheduler
+using MAT
 
 # TODO make a test to check if this value is updated
 # with Pkg.TOML.parsefile(joinpath(pkgdir(EEGIO), "Project.toml"))["version"]
@@ -31,6 +32,11 @@ include("formats/EEG.jl")
 include("load/load_eeg.jl")
 include("save/save_eeg.jl")
 export EEG, EEGHeader, EEGMarkers, read_eeg, write_eeg
+
+# SET files
+include("formats/SET.jl")
+include("load/load_set.jl")
+export SET, SETHeader, read_set
 
 # Convenient type unions
 BEDFHeader = Union{BDFHeader, EDFHeader}

--- a/src/formats/EEG.jl
+++ b/src/formats/EEG.jl
@@ -277,7 +277,7 @@ end
 Base.show(io::IO, eeg::EEGHeader) = print(io, "EEG Header")
 Base.show(io::IO, eeg::EEGMarkers) = print(io, "EEG Markers")
 
-function Base.show(io::IO, eeg::EEGData)
+function Base.show(io::IO, eeg::EEG)
     print(io,
     "EEG file ($(eeg.header.common["NumberOfChannels"]) channels, \
     duration: $(round(size(eeg.data, 1)/(1_000_000/eeg.header.common["SamplingInterval"]*60),digits=2)) min.)"

--- a/src/formats/SET.jl
+++ b/src/formats/SET.jl
@@ -1,0 +1,95 @@
+mutable struct SETChannels
+    labels::Vector{String}
+    type::Vector{String}
+    ref::Vector{String}
+    identifier::Vector{Int64}
+    description::Vector{String}
+    urchan::Vector{Any}
+    X::Vector{Float64}
+    Y::Vector{Float64}
+    Z::Vector{Float64}
+    theta::Vector{Float64}
+    radius::Vector{Float64}
+    sph_phi::Vector{Float64}
+    sph_radius::Vector{Float64}
+    sph_theta::Vector{Float64}
+end
+
+SETChannels() = SETChannels(
+    String[],String[],String[],Int[],String[], Any[],
+    Float64[],Float64[],Float64[],Float64[],Float64[],Float64[],Float64[],Float64[]
+)
+
+mutable struct SETHeader <: Header
+    # Basic information
+    setname::String
+    trials::Int64
+    pnts::Int64
+    nbchan::Int64
+    srate::Float64
+    xmin::Float64
+    xmax::Float64
+    times::Vector{Float64}
+    ref::Union{String, Int64}
+    history::Union{String, Vector{String}}
+    comments::String
+    etc::Dict{String, Any}
+    saved::Union{String, Bool}
+    # Data file
+    datfile::String
+    # Chennel locations
+    chanlocs::SETChannels
+    urchanlocs::Dict{String, Any}
+    chaninfo::Dict{String, Any}
+    splinefile::String
+    # Events and epochs
+    event::Dict{String, Any}
+    urevent::Dict{String, Any}
+    epoch::Dict{String, Any}
+    eventdescription::Vector{String}
+    epochdescription::Vector{String}
+    # ICA
+    icasphere::Array
+    icaweights::Array
+    icawinv::Array
+    icaact::Array
+    icasplinefile::String
+    icachansind::Vector{Int64}
+    dipfit::Dict{String, Any}
+    # Dataset membership
+    subject::String
+    group::String
+    condition::String
+    run::Int
+    session::Int
+    # Data rejection
+    specdata::Array
+    specicaact::Array
+    stats::Dict{String, Any}
+    reject::Dict{String, Any}
+end
+
+# This is extremally ugly, but can be updated afterwards, reducing the need for a huge constructor later
+SETHeader() = SETHeader(
+    "", 0, 0, 0, 0., 0., 0., Float64[], 0, String[], "", Dict(), false,
+    "", SETChannels(), Dict(), Dict(), "", Dict(), Dict(), Dict(), String[], String[],
+    zeros(0,0), zeros(0,0), zeros(0,0), zeros(0,0), "", Int64[], Dict(),
+    "", "", "", 0, 0, zeros(0,0), zeros(0,0), Dict(), Dict()
+)
+
+mutable struct SET <: EEGData
+    header::SETHeader
+    data::Array
+    path::String
+    file::String
+end
+
+Base.show(io::IO, set::EEGHeader) = print(io, "SET Header")
+Base.show(io::IO, set::EEGMarkers) = print(io, "SET Markers")
+
+function Base.show(io::IO, set::SET)
+    print(io,
+    "SET file ($(set.header.nbchan) channels, \
+    duration: $(round((set.header.pnts/(set.header.srate*60)),digits=2)) min.)"
+    )
+end

--- a/src/formats/SET.jl
+++ b/src/formats/SET.jl
@@ -1,10 +1,33 @@
+"""
+    SETChannels(
+        labels::Vector{String},
+        type::Vector{String},
+        ref::Vector{String},
+        identifier::Vector{Int64},
+        description::Vector{String},
+        urchan::Vector{Float64},
+        X::Vector{Float64},
+        Y::Vector{Float64},
+        Z::Vector{Float64},
+        theta::Vector{Float64},
+        radius::Vector{Float64},
+        sph_phi::Vector{Float64},
+        sph_radius::Vector{Float64},
+        sph_theta::Vector{Float64}
+    )
+
+Struct for storing channel information from SET files.
+Follows roughly the specification that can be found in eeg_checkchanlocs.m file from EEGLab.
+Only channel labels seem to be obligatory, the rest is optional and can be left empty.
+Does not include legacy/depracated fields as EEGLab mostly omits them itself.
+"""
 mutable struct SETChannels
     labels::Vector{String}
     type::Vector{String}
     ref::Vector{String}
     identifier::Vector{Int64}
     description::Vector{String}
-    urchan::Vector{Any}
+    urchan::Vector{Float64}
     X::Vector{Float64}
     Y::Vector{Float64}
     Z::Vector{Float64}
@@ -15,11 +38,63 @@ mutable struct SETChannels
     sph_theta::Vector{Float64}
 end
 
+"""
+    SETChannels()
+
+Empty SETChannels constructor. All fields are initialized as empty vectors of the appropriate type.
+"""
 SETChannels() = SETChannels(
     String[],String[],String[],Int[],String[], Any[],
     Float64[],Float64[],Float64[],Float64[],Float64[],Float64[],Float64[],Float64[]
 )
 
+"""
+    SETHeader(
+        setname::String,
+        trials::Int64,
+        pnts::Int64,
+        nbchan::Int64,
+        srate::Float64,
+        xmin::Float64,
+        xmax::Float64,
+        times::Vector{Float64},
+        ref::Union{String, Int64},
+        history::Union{String, Vector{String}},
+        comments::String,
+        etc::Dict{String, Any},
+        saved::Union{String, Bool},
+        raw::Dict{String, Any},
+        datfile::String,
+        chanlocs::SETChannels,
+        urchanlocs::Dict{String, Any},
+        chaninfo::Dict{String, Any},
+        splinefile::String,
+        event::Dict{String, Any},
+        urevent::Dict{String, Any},
+        epoch::Dict{String, Any},
+        eventdescription::Vector{String},
+        epochdescription::Vector{String},
+        icasphere::Array,
+        icaweights::Array,
+        icawinv::Array,
+        icaact::Array,
+        icasplinefile::String,
+        icachansind::Vector{Int64},
+        dipfit::Dict{String, Any},
+        subject::String,
+        group::String,
+        condition::String,
+        run::Int,
+        session::Int,
+        specdata::Array,
+        specicaact::Array,
+        stats::Dict{String, Any},
+        reject::Dict{String, Any}
+    )
+
+Struct for storing EEG header information.
+Follows roughly the specification that can be found in eeg_checkset.m file from EEGLab.
+"""
 mutable struct SETHeader <: Header
     # Basic information
     setname::String
@@ -35,6 +110,7 @@ mutable struct SETHeader <: Header
     comments::String
     etc::Dict{String, Any}
     saved::Union{String, Bool}
+    raw::Dict{String, Any}
     # Data file
     datfile::String
     # Chennel locations
@@ -69,14 +145,27 @@ mutable struct SETHeader <: Header
     reject::Dict{String, Any}
 end
 
+"""
+    SETHeader()
+
+Empty SETHeader constructor. All fields are initialized as empty values of the appropriate type.
+"""
 # This is extremally ugly, but can be updated afterwards, reducing the need for a huge constructor later
 SETHeader() = SETHeader(
-    "", 0, 0, 0, 0., 0., 0., Float64[], 0, String[], "", Dict(), false,
+    "", 0, 0, 0, 0., 0., 0., Float64[], 0, String[], "", Dict(), false, Dict(),
     "", SETChannels(), Dict(), Dict(), "", Dict(), Dict(), Dict(), String[], String[],
     zeros(0,0), zeros(0,0), zeros(0,0), zeros(0,0), "", Int64[], Dict(),
     "", "", "", 0, 0, zeros(0,0), zeros(0,0), Dict(), Dict()
 )
 
+"""
+    SET(header::SETHeader, data::Array, path::String, file::String)
+
+Struct for storing EEG data from SET files.
+Header contains all metadata from the .set file. Data is a 2D array (samples x channels).
+Currently, no convenient constructors are provided, as the writing to file functionality 
+is not yet implemented.
+"""
 mutable struct SET <: EEGData
     header::SETHeader
     data::Array

--- a/src/formats/SET.jl
+++ b/src/formats/SET.jl
@@ -84,8 +84,8 @@ mutable struct SET <: EEGData
     file::String
 end
 
-Base.show(io::IO, set::EEGHeader) = print(io, "SET Header")
-Base.show(io::IO, set::EEGMarkers) = print(io, "SET Markers")
+Base.show(io::IO, set::SETHeader) = print(io, "SET Header")
+Base.show(io::IO, set::SETChannels) = print(io, "SET Channels")
 
 function Base.show(io::IO, set::SET)
     print(io,

--- a/src/load/load_edf.jl
+++ b/src/load/load_edf.jl
@@ -197,7 +197,7 @@ function read_edf_data!(raw::Vector, data, header, recSamples, records, chans, s
             dataEnd = Vector{Int}(undef, length(chans))
         end
 
-        parse_record!(raw, data, header, records, ridx, recSamples, chans, chanOffset, dataStart[], dataEnd[], scaleFactors, offsets)
+        parse_record!(raw, data, header, records, ridx, recSamples, chans, chanOffset, dataStart, dataEnd, scaleFactors, offsets)
     end
 
     return nothing

--- a/src/load/load_eeg.jl
+++ b/src/load/load_eeg.jl
@@ -1,8 +1,3 @@
-# TODO: cover cases when user wants to read vhdr or vmrk file instead of eeg
-# TODO: read data and markers from files stated in vhdr file
-# TODO: check correctness with other files
-# TODO: Decide what to do with comment section - read it in or leave out?
-
 """
     read_eeg(f::String; kwargs...)
 
@@ -265,8 +260,6 @@ function parse_channels(fid)
     )
     if size(channels)[1] == 5
         chans["unit"] = channels[5,:]
-    elseif size(channels)[1] == 4
-        chans["unit"] = "µV"
     end
     return chans, line
 end
@@ -371,14 +364,14 @@ function read_eeg_data(fid::IO, header::EEGHeader, markers::EEGMarkers, numPreci
     raw = read_method(fid, method, Matrix{header.binary}, (nDataChannels, nDataSamples))
     data = Array{numPrecision}(undef, (nSamples, nChannels))
 
-    convert_data!(raw, data, header, nDataChannels, nDataSamples, samples, chans, resolution, bytes, tasks)
+    convert_data!(raw, data, header.binary, nDataChannels, nDataSamples, samples, chans, resolution, bytes, tasks)
 
     finalize(raw)
     return data
 end
 
 # Mmap version
-function convert_data!(raw::Array, data, header, nDataChannels, nDataSamples, samples, chans, resolution, bytes, tasks)
+function convert_data!(raw::Array, data, dataType, nDataChannels, nDataSamples, samples, chans, resolution, bytes, tasks)
 
     @tasks for sidx in eachindex(samples)
         @set scheduler = DynamicScheduler(; nchunks=tasks)
@@ -389,14 +382,14 @@ function convert_data!(raw::Array, data, header, nDataChannels, nDataSamples, sa
 end
 
 # Direct version
-function convert_data!(raw::IO, data, header, nDataChannels, nDataSamples, samples, chans, resolution, bytes, tasks)
+function convert_data!(raw::IO, data, dataType::Type, nDataChannels, nDataSamples, samples, chans, resolution, bytes, tasks)
     readLock = ReentrantLock()
 
     # Divide the input data into 2 MB chunks to reduce the number of read calls
     offset = nDataChannels * bytes
     maxChunk = 2_000_000 ÷ offset
 
-    scratch = TaskLocalValue{Array{header.binary}}(() -> Array{header.binary}(undef, (nDataChannels, maxChunk)))
+    scratch = TaskLocalValue{Array{dataType}}(() -> Array{dataType}(undef, (nDataChannels, maxChunk)))
     
     filechunks = collect(partition(1:length(samples), maxChunk))
 
@@ -416,7 +409,7 @@ function convert_chunk!(raw::IO, chunk, scratch, data, samples, chans, resolutio
     end
 
     for dataIdx in eachindex(chunk)
-        convert_chunk!(scratch, data, samples[chunk[dataIdx]], dataIdx, chans, resolution)
+        convert_chunk!(scratch, data, chunk[dataIdx], dataIdx, chans, resolution)
     end
 
     return nothing

--- a/src/load/load_eeg.jl
+++ b/src/load/load_eeg.jl
@@ -395,7 +395,7 @@ function convert_data!(raw::IO, data, dataType::Type, nDataChannels, nDataSample
         @set ntasks = tasks
         @local scratch = Array{dataType}(undef, (nDataChannels, maxChunk))
 
-        convert_chunk!(raw, chunk, scratch[], data, samples, chans, resolution, offset, readLock)
+        convert_chunk!(raw, chunk, scratch, data, samples, chans, resolution, offset, readLock)
     end
 
     return nothing

--- a/src/load/load_set.jl
+++ b/src/load/load_set.jl
@@ -1,7 +1,19 @@
 function read_set(f::String; kwargs...)
     # Check if an existing path is given, then open the file
-    if ispath(f)
+    if isfile(f)
         path, file = splitdir(f)
+
+        # Check if it is a .fdt file and search for .set if yes
+        root, ext = splitext(file)
+        if ext == ".fdt"
+            f = joinpath(path, root * ".set")
+            if !isfile(f)
+                error("$f file was expected, but does not exist.")
+            end
+        elseif ext != ".set"
+            error("Expected a SET or FDT file, got $file.")
+        end
+
         matopen(f) do fid
             read_set(fid; path=path, file=file, kwargs...)
         end

--- a/src/load/load_set.jl
+++ b/src/load/load_set.jl
@@ -1,3 +1,64 @@
+"""
+    read_set(f::String; kwargs...)
+
+Reads EEG data from a SET file.
+
+Providing a string containing valid path to a .set or .fdt file will result in reading 
+the data as a Float64 matrix (provided all files share their name). Behavior of the function 
+can be altered through additional keyword arguments listed below. Please consult the online 
+documentation for a more thorough explanation of different options.
+
+## Arguments:
+- `f::String`
+    - Path to the SET file (either .set or .fdt) to be read.
+
+## Keywords:
+- `onlyHeader::Bool=false`
+    - Indicates whether to read only the metadata information from the .set file.
+- `numPrecision::Type=Float64`
+    - Specifies the numerical type of the data. Data points in SET and FDT files are stored 
+      as 32-bit floats, therefore can be read as types with higher bit count per number.
+      However, currently data stored within .set files is always read as Float64 (limitations
+      of MAT.jl library that this package depends on) therefore ignoring this setting. For
+      data stored in separate .fdt files, possible tested options are: `Float32`, `Float64`, 
+      `Int32`, `Int64`. Since there is no clear benefit (except amount of memory used) to 
+      using smaller number, the default is set to `Float64`.
+- `chanSelect::Union{Int, Range, Vector{Int}, String, Vector{String}, Regex, Symbol}=:All`
+    - Specifies the subset of channels to read from the data. Depending on the provided value
+      you can select different subsets of channels.
+      Using integers (either single number, range, or a vector) will select channels by their
+      position in the data (e.g. chanSelect=[1,4,8], will pick the first, fourth, and eighth).
+      Using strings or regex expression will pick all the channels with matching names stored
+      in the header.
+      Finally, you can provide symbols :None or :All to read neither or every channel available.
+      Default is set to :All.
+- `chanIgnore::Union{Int, UnitRange, Vector{Int}, String, Vector{String}, Regex, Symbol}=:None`
+    - Specifies the subset of channel to omit while reading the data.
+      Uses the same selectors as `chanSelect` and picked values are subtracted from the set
+      of electrodes chosen by `chanSelect`. Default is set to :None.
+- `timeSelect::Union{Int, UnitRange, Tuple{AbstractFloat}, Symbol}=:All`
+    - Specifies the part of the time course of the data to be read.
+      Using integers will select samples with those indexes in the data.
+      Using a tuple of floats will be interpreted as start and stop values in seconds
+      and all samples that fit this time span will be read.
+      Using Symbol :All will read every sample in the file. This is also the default.
+- `method::Symbol=:Direct`
+    - Choose the IO method of reading data. Can be either :Direct (set as the default) for 
+      reading the file in chunks or :Mmap for using memory mapping. This setting is ignored
+      for .set files, as they are always read in directly by MAT.jl.
+- `tasks::Int=1`
+    - Specifies how many concurent tasks will be spawn to read chunks of data. Tasks will use
+      as many threads as there are available to Julia, but users can specify a higher number.
+      Default is set to 1 (equal to single threaded run).
+
+SET files are just MATLAB data structures saved in a file with a .set extension. They have
+a specific structure imposed by the EEGLab software, but individual users might alter it
+manually to contain additional fields or data types. There were also changes in the format
+over the years, so there is always a possibility that some data were not extracted.
+MAT.jl library reads in the data as a single dictionary, which is then parsed by this function.
+To allow users to inspect all of the original metadata, it is being stored in the header field
+`raw`. Please check it if you suspect some data are missing.
+"""
 function read_set(f::String; kwargs...)
     # Check if an existing path is given, then open the file
     if isfile(f)
@@ -32,6 +93,7 @@ function read_set(fid; path="", file="", onlyHeader=false, addOffset=true, numPr
     # Read the header
     header, rawData = read_set_header(raw)
 
+    # If the data is stored in a separate file, read it
     if typeof(rawData) == String
         if onlyHeader || isempty(rawData)
             data = Array{Float64}(undef, (0,0))
@@ -52,8 +114,11 @@ function read_set(fid; path="", file="", onlyHeader=false, addOffset=true, numPr
             data = read_set_data(rawDataPath, header, numPrecision, chanSelect, chanIgnore, timeSelect, method, tasks)
         end
 
+    # If the data is already in the file, read it
     elseif typeof(rawData) <: AbstractArray
         data = read_set_data(rawData, header, numPrecision, chanSelect, chanIgnore, timeSelect, tasks)
+        # Remove the raw signal data from the header
+        header.raw["data"] = ""
     else
         error("EEG data in file is of unknown type: $(type(rawData)).")
     end
@@ -61,6 +126,7 @@ function read_set(fid; path="", file="", onlyHeader=false, addOffset=true, numPr
     return SET(header, data, path, file)
 end
 
+# Find the EEG dataset in the file
 function find_set_data(fid)
     vars = keys(fid)
     if "EEG" in vars
@@ -73,6 +139,11 @@ function find_set_data(fid)
     end
 end
 
+"""
+    read_set_header(raw::Dict)
+
+Reads the metadata from the raw dictionary provided by MAT.jl and creates a SETHeader object.
+"""
 function read_set_header(raw::Dict)
     rawKeys = keys(raw)
 
@@ -95,11 +166,15 @@ function read_set_header(raw::Dict)
         end
     end
 
+    # Store the original metadata in the header
+    setproperty!(header, :raw, raw)
+
     rawData = raw["data"]
 
     return header, rawData
 end
 
+# Parse channel information into a SETChannels object
 function parse_set_channels(rawchans)
     rawKeys = keys(rawchans)
 
@@ -121,6 +196,7 @@ function parse_set_channels(rawchans)
     return channels
 end
 
+# Convert channel data into vectors
 function normalize_chans(rawVector, outputType)
     return vec(map(x -> isempty(x) ? get_zero(outputType) : x, rawVector))
 end
@@ -129,6 +205,7 @@ get_zero(T::Any) = nothing
 get_zero(T::Type{<:Number}) = zero(T)
 get_zero(T::Type{<:AbstractString}) = ""
 
+# Read data that is stored in the .set file
 function read_set_data(rawData::Array, header::SETHeader, numPrecision, chanSelect, chanIgnore, timeSelect, tasks)
     dims = size(rawData)
     flip = header.nbchan == dims[1] ? true : false
@@ -184,6 +261,7 @@ function read_set_data(rawData::String, args...)
     end
 end
 
+# Read data that is stored in a separate .fdt file
 function read_set_data(rawData::IO, header::SETHeader, numPrecision, chanSelect, chanIgnore, timeSelect, method, tasks)
     rawChans = header.nbchan
     rawSamples = header.pnts

--- a/src/load/load_set.jl
+++ b/src/load/load_set.jl
@@ -1,0 +1,208 @@
+function read_set(f::String; kwargs...)
+    # Check if an existing path is given, then open the file
+    if ispath(f)
+        path, file = splitdir(f)
+        matopen(f) do fid
+            read_set(fid; path=path, file=file, kwargs...)
+        end
+    else
+        error("$f is not a valid file path.")
+    end
+end
+
+# Internal function called by public API
+function read_set(fid; path="", file="", onlyHeader=false, addOffset=true, numPrecision=Float64, 
+    chanSelect=:All, chanIgnore=:None, timeSelect=:All, method=:Direct, tasks=1)
+
+    # Check if the data is nested
+    raw = find_set_data(fid)
+
+    # Read the header
+    header, rawData = read_set_header(raw)
+
+    if typeof(rawData) == String
+        if onlyHeader || isempty(rawData)
+            data = Array{Float64}(undef, (0,0))
+        else
+            if isfile(joinpath(path, rawData))
+                rawDataPath = joinpath(path, rawData)
+
+            else
+                root, ext = splitext(file)
+                rawDataPath = joinpath(path, root * ".fdt")
+                if !isfile(rawDataPath)
+                    error("Could not find the data file associated with the SET file. Please check 
+                    if they are in the same folder.")
+                end
+                @warn "SET file was pointing to non-existing file, but an FDT file with the same name
+                was found in the folder - reading it instead."
+            end
+            data = read_set_data(rawDataPath, header, numPrecision, chanSelect, chanIgnore, timeSelect, method, tasks)
+        end
+
+    elseif typeof(rawData) <: AbstractArray
+        data = read_set_data(rawData, header, numPrecision, chanSelect, chanIgnore, timeSelect)
+    else
+        error("EEG data in file is of unknown type: $(type(rawData)).")
+    end
+
+    return SET(header, data, path, file)
+end
+
+function find_set_data(fid)
+    vars = keys(fid)
+    if "EEG" in vars
+        return read(fid, "EEG")
+    # Check for presence of one of obligatory fields
+    elseif "setname" in vars
+        return read(fid)
+    else
+        error("Could not find EEGLab data in the file. Only these fields are present: $vars.")
+    end
+end
+
+function read_set_header(raw::Dict)
+    rawKeys = keys(raw)
+
+    header = SETHeader()
+    
+    hNames = fieldnames(SETHeader)
+    hTypes = fieldtypes(SETHeader)
+
+    for i in eachindex(hNames)
+        name = String(hNames[i])
+        if (name in rawKeys) && !isempty(raw[name])
+            if name == "chanlocs"
+                channels = parse_set_channels(raw[name])
+                setproperty!(header, hNames[i], channels)
+            elseif typeof(raw[name]) <: AbstractMatrix && (1 in size(raw[name]))
+                setproperty!(header, hNames[i], vec(raw[name]))
+            else
+                setproperty!(header, hNames[i], raw[name])
+            end
+        end
+    end
+
+    rawData = raw["data"]
+
+    return header, rawData
+end
+
+function parse_set_channels(rawchans)
+    rawKeys = keys(rawchans)
+
+    channels = SETChannels()
+
+    cNames = fieldnames(SETChannels)
+
+    for i in eachindex(cNames)
+        name = String(cNames[i])
+        if (name in rawKeys) && !isempty(rawchans[name])
+            if typeof(rawchans[name]) <: AbstractMatrix && (1 in size(rawchans[name]))
+                setproperty!(channels, cNames[i], normalize_chans(rawchans[name], eltype(getfield(channels, cNames[i]))))
+            else
+                setproperty!(channels, cNames[i], rawchans[name])
+            end
+        end
+    end
+
+    return channels
+end
+
+function normalize_chans(rawVector, outputType)
+    return vec(map(x -> isempty(x) ? get_zero(outputType) : x, rawVector))
+end
+
+get_zero(T::Any) = nothing
+get_zero(T::Type{<:Number}) = zero(T)
+get_zero(T::Type{<:AbstractString}) = ""
+
+function read_set_data(rawData::Array, header::SETHeader, numPrecision, chanSelect, chanIgnore, timeSelect)
+    dims = size(rawData)
+    flip = header.nbchan == dims[1] ? true : false
+
+    # Check if the number of samples matches the metadata
+    header.pnts in dims ? nothing : warn("Data has different number of samples than declared in the metadata.")
+    
+    # Select a subset of channels/samples if user specified a narrower scope.
+    chans = pick_channels(header, chanSelect)
+    chans = setdiff(chans, pick_channels(header, chanIgnore))
+    nChannels = length(chans)
+
+    samples = pick_samples(header, timeSelect)
+    nSamples = length(samples)
+
+    # Flip the dimentions or just return the array, if it is not necessary
+    dims = flip ? reverse(dims) : dims
+
+    # Return the raw matrix if new dimensions are the same
+    !flip && dims == (nSamples, nChannels) && return rawData
+
+    data = Array{numPrecision}(undef, (nSamples, nChannels))
+
+    flip ? flip_copy!(rawData, data, chans, samples) : noflip_copy!(rawData, data, chans, samples)
+
+    update_header!(header, chans)
+    update_header!(header, samples)
+
+    return data
+end
+
+function flip_copy!(rawData, data, chans, samples)
+    for sIdx in samples
+        @views data[sIdx,:] .= rawData[chans, sIdx]
+    end
+end
+
+function noflip_copy!(rawData, data, chans, samples)
+    for sIdx in samples
+        @views data[sIdx,:] .= rawData[sIdx, chans]
+    end
+end
+
+function read_set_data(rawData::String, args...)
+    if isfile(rawData)
+        open(rawData) do fid
+            read_set_data(fid, args...)
+        end
+    else
+        error("$rawData is not a valid file path.")
+    end
+end
+
+function read_set_data(rawData::IO, header::SETHeader, numPrecision, chanSelect, chanIgnore, timeSelect, method, tasks)
+    rawChans = header.nbchan
+    rawSamples = header.pnts
+    rawSize = rawChans * rawSamples
+
+    # Assume files contain Float32 numbers.
+    dataType = Float32
+    dataSize = sizeof(dataType)
+    # Check if the size of data in the file matches parameters from the header
+    seekend(rawData)
+    if !(position(rawData) ÷ dataSize == rawSize)
+        error("Data from file $(header.datfile) does not match the amount declared in the SET file.")
+    end
+    seekstart(rawData)
+    
+    # Select a subset of channels/samples if user specified a narrower scope.
+    chans = pick_channels(header, chanSelect)
+    chans = setdiff(chans, pick_channels(header, chanIgnore))
+    nChannels = length(chans)
+
+    samples = pick_samples(header, timeSelect)
+    nSamples = length(samples)
+
+    raw = read_method(rawData, method, Vector{dataType}, rawSize)
+    data = Array{numPrecision}(undef, nSamples, nChannels)
+
+    resolution = ones(numPrecision, rawChans)
+    # We will use convert functions for EEG files as both filetypes use Float32 and similar 
+    # data alignment.
+    convert_data!(raw, data, dataType, rawChans, rawSamples, samples, chans, resolution, dataSize, 1)
+
+    update_header!(header, chans)
+    update_header!(header, samples)
+
+    return data
+end

--- a/src/load/load_set.jl
+++ b/src/load/load_set.jl
@@ -150,14 +150,14 @@ end
 
 function flip_copy!(rawData, data, chans, samples, tasks)
     @tasks for sIdx in samples
-        @set scheduler = DynamicScheduler(; nchunks=tasks)
+        @set ntasks=tasks
         @views data[sIdx,:] .= rawData[chans, sIdx]
     end
 end
 
 function noflip_copy!(rawData, data, chans, samples, tasks)
     @tasks for sIdx in samples
-        @set scheduler = DynamicScheduler(; nchunks=tasks)
+        @set ntasks=tasks
         @views data[sIdx,:] .= rawData[sIdx, chans]
     end
 end

--- a/src/utils/pick_channels.jl
+++ b/src/utils/pick_channels.jl
@@ -95,3 +95,4 @@ end
 channel_info(header::BDFHeader) = header.nChannels, header.chanLabels
 channel_info(header::EDFHeader) = header.nChannels, header.chanLabels
 channel_info(header::EEGHeader) = header.common["NumberOfChannels"], header.channels["name"]
+channel_info(header::SETHeader) = header.nbchan, header.chanlocs.labels

--- a/src/utils/pick_samples.jl
+++ b/src/utils/pick_samples.jl
@@ -105,3 +105,43 @@ function pick_samples(header::EEGHeader, times::Tuple{AbstractFloat, AbstractFlo
         error("Time range $times does not fit the available length of the data: $signalTime")
     end
 end
+
+# SET selection
+function pick_samples(header::SETHeader, records::Symbol)
+    if records == :All
+        return 1:header.pnts
+    else
+        error("Unknown symbol :$records passed. Did You mean :All?")
+    end
+end
+
+# Integer interpreted as a single sample.
+function pick_samples(header::SETHeader, sample::Integer)
+    if 0 < sample < header.pnts
+        return sample:sample
+    else
+        error("Number of a record to read should be between 1 and $(header.pnts). Got $sample instead.")
+    end
+end
+
+# Unitrange interpreted as an interval of samples the should be read.
+function pick_samples(header::SETHeader, samples::UnitRange)
+    if samples[1] >= 1 && samples[end] <= header.pnts
+        return samples
+    else
+        error("Range $samples does not fit in the available $(header.pnts) records.")
+    end
+end
+
+# Tuple of floats interpreted as seconds. All samples fitting it will be read.
+# This follows the Julia convention, where end of an interval is also included.
+function pick_samples(header::SETHeader, times::Tuple{AbstractFloat, AbstractFloat})
+    sRate = header.srate
+    signalTime = header.pnts / sRate
+
+    if 0 <= times[1] && times[2] <= signalTime
+        return round(Int, (times[1]-1)*sRate+1):round(Int, times[2]*sRate)
+    else
+        error("Time range $times does not fit the available length of the data: $signalTime")
+    end
+end


### PR DESCRIPTION
This pull request implements reading SET files containing data and metadata from EEGLab. Since these files are just MAT files with a certain structure, we are leveraging existing library `MAT.jl` to handle the initial reading into memory and just reorganizing it into a dedicated struct.

This approach is convenient, but has significant drawbacks compared to other formats: we have little contol over inital data read as well as no option to save data back into SET files.
MAT.jl cannot reliably read in data and then replicate the original layout while saving. I corrected the initial type-related errors, but while file managed to get saved, EEGLab expected `chanlocs` and `event` fields in a different format, that I couldn't figure out in `MAT.jl`.

It would be useful to reimplement these functionalities from scratch, but it has low priority at the moment. The most reliable way of transferring data into EEGLab would be to use any other BIDS-approved format.

Recently EEGLab defaults to writing one single file instead of two (separate data and metadata) and using the new format based on HDF5.
However, when the data is split into two files, we can have more control over reading the signal itself, using functions for EEG files (same Float32 data size 
 and layout). When everything is in one file, user can't choose the read method, so the keyword is ignored (but we keep it for compatibility with general API).